### PR TITLE
Websocket handler context path can be specified with a :path option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ See the [in-depth example](example/) for fancy core.match message dispatch and a
 (def c (chan))
 
 (def ws-configurator
-  (configurator c))
+  (configurator c {:path "/"}))
 
 (def server
   (run-jetty http-handler {:configurator ws-configurator

--- a/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
+++ b/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
@@ -48,15 +48,16 @@ Request maps contain following keys:
 
 Accepts the following options:
 
-  :send - a zero-arg function called to create the :send port for each new websocket connection
-  :recv - a zero-arg function called to create the :recv port for each new websocket connection"
-
+  :send - a zero-arg function called to create the :send port for each new websocket connection (default: a non-blocking dropping channel)
+  :recv - a zero-arg function called to create the :recv port for each new websocket connection (default: a non-blocking dropping channel)
+"
   ([connection-chan url]
-     (connect! connection-chan url {:send default-chan :recv default-chan}))
-  ([connection-chan url options]
+     (connect! connection-chan url {}))
+  ([connection-chan url {:keys [send recv]
+                         :or {send default-chan, recv default-chan}}]
      (.open (.newWebSocketClient ws-client-factory)
             (URI. url)
-            (->WebSocket$OnTextMessage connection-chan url ((:send options)) ((:recv options))))))
+            (->WebSocket$OnTextMessage connection-chan url (send) (recv)))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;WebSocket server


### PR DESCRIPTION
This also fixes some unintended behavior of the options map: since we were specifying option defaults in another arity, specifying any options required you to specify all options. (E.g. passing {:send chan} would cause :recv to be nil.) This is now handled with :or style defaults.
