### PR TITLE
Update key names in example

### DIFF
--- a/example/src/clj/com/keminglabs/jetty7_websockets_async/example/core.clj
+++ b/example/src/clj/com/keminglabs/jetty7_websockets_async/example/core.clj
@@ -14,10 +14,10 @@
   (go
     (while true
       (match [(<! conn-chan)]
-        [{:uri uri :send send :recv recv}]
+        [{:uri uri :in in :out out}]
         (go
-          (>! send "Yo")
+          (>! in "Yo")
           (loop []
-            (when-let [msg (<! recv)]
+            (when-let [msg (<! out)]
               (prn msg)
               (recur))))))))


### PR DESCRIPTION
Looks like send/recv are old names that were replaced with in/out
