### PR TITLE
Build & pass request map, not just URI

### DIFF
--- a/example/src/clj/com/keminglabs/jetty7_websockets_async/example/core.clj
+++ b/example/src/clj/com/keminglabs/jetty7_websockets_async/example/core.clj
@@ -14,7 +14,7 @@
   (go
     (while true
       (match [(<! conn-chan)]
-        [{:uri uri :send send :recv recv}]
+        [{:request request :send send :recv recv}]
         (go
           (>! send "Yo")
           (loop []

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
 
   :profiles {:dev {:source-paths ["dev" "example/src/clj"]
                    :dependencies [[ring/ring-jetty-adapter "1.2.0"]
+                                  [ring/ring-servlet "1.2.0"]
                                   [compojure "1.1.5" :exclusions [ring/ring-core]]
                                   [org.clojure/core.match "0.2.0-rc5"]
                                   [midje "1.5.1"]]}}

--- a/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
+++ b/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
@@ -40,18 +40,18 @@
 ;;TODO: how to prevent docstring duplication?
 (defn connect!
   "Tries to connect to websocket at `url`; if sucessful, places a request map on `connection-chan`.
-  Request maps contain following keys:
+Request maps contain following keys:
 
   :uri  - the string URI on which the connection was made
   :conn - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
   :in   - a core.async port where you can put string messages
   :out  - a core.async port whence string messages
 
-  Accepts the following options:
+Accepts the following options:
 
   :in   - a zero-arg function called to create the :in port for each new websocket connection (default: a non-blocking dropping channel)
   :out  - a zero-arg function called to create the :out port for each new websocket connection (default: a non-blocking dropping channel)
-  "
+"
   ([connection-chan url]
    (connect! connection-chan url {}))
   ([connection-chan url {:keys [in out]

--- a/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
+++ b/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
@@ -10,10 +10,10 @@
   (chan (dropping-buffer 137)))
 
 (defn ->WebSocket$OnTextMessage
-  [connection-chan request in out]
+  [connection-chan {:keys [in out] :as connection-msg}]
   (proxy [WebSocket$OnTextMessage] []
     (onOpen [conn]
-      (>!! connection-chan {:request request :conn conn :in in :out out})
+      (>!! connection-chan (assoc connection-msg :conn conn))
       (go (loop []
             (let [^String msg (<! in)]
               (if (nil? msg)
@@ -40,25 +40,26 @@
 ;;TODO: how to prevent docstring duplication?
 (defn connect!
   "Tries to connect to websocket at `url`; if sucessful, places a request map on `connection-chan`.
-Request maps contain following keys:
+  Request maps contain following keys:
 
-  :request - basic ring request map
-  :conn    - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
-  :in      - a core.async port where you can put string messages
-  :out     - a core.async port whence string messages
+  :uri  - the string URI on which the connection was made
+  :conn - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
+  :in   - a core.async port where you can put string messages
+  :out  - a core.async port whence string messages
 
-Accepts the following options:
+  Accepts the following options:
 
   :in   - a zero-arg function called to create the :in port for each new websocket connection (default: a non-blocking dropping channel)
   :out  - a zero-arg function called to create the :out port for each new websocket connection (default: a non-blocking dropping channel)
-"
+  "
   ([connection-chan url]
-     (connect! connection-chan url {}))
+   (connect! connection-chan url {}))
   ([connection-chan url {:keys [in out]
                          :or {in default-chan, out default-chan}}]
-     (.open (.newWebSocketClient ws-client-factory)
-            (URI. url)
-            (->WebSocket$OnTextMessage connection-chan url (in) (out)))))
+   (.open (.newWebSocketClient ws-client-factory)
+          (URI. url)
+          (->WebSocket$OnTextMessage connection-chan
+                                     {:uri url :in (in) :out (out)}))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;WebSocket server
@@ -68,7 +69,10 @@ Accepts the following options:
   (proxy [WebSocketHandler] []
     (doWebSocketConnect [request response]
       (let [in (in-thunk) out (out-thunk)]
-        (->WebSocket$OnTextMessage connection-chan (servlet/build-request-map request) in out)))))
+        (->WebSocket$OnTextMessage connection-chan
+                                   {:request (servlet/build-request-map request)
+                                    :in in
+                                    :out out})))))
 
 (defn configurator
   "Returns a Jetty configurator that configures server to listen for websocket connections and put request maps on `connection-chan`.

--- a/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
+++ b/src/clj/com/keminglabs/jetty7_websockets_async/core.clj
@@ -1,5 +1,6 @@
 (ns com.keminglabs.jetty7-websockets-async.core
-  (:require [clojure.core.async :refer [go chan close! <!! <! >!! >! dropping-buffer]])
+  (:require [clojure.core.async :refer [go chan close! <!! <! >!! >! dropping-buffer]]
+            [ring.util.servlet :as servlet])
   (:import (org.eclipse.jetty.websocket WebSocket WebSocket$OnTextMessage WebSocketHandler WebSocketClientFactory)
            org.eclipse.jetty.server.handler.ContextHandler
            org.eclipse.jetty.server.handler.ContextHandlerCollection
@@ -9,10 +10,10 @@
   (chan (dropping-buffer 137)))
 
 (defn ->WebSocket$OnTextMessage
-  [connection-chan uri in out]
+  [connection-chan request in out]
   (proxy [WebSocket$OnTextMessage] []
     (onOpen [conn]
-      (>!! connection-chan {:uri uri :conn conn :in in :out out})
+      (>!! connection-chan {:request request :conn conn :in in :out out})
       (go (loop []
             (let [^String msg (<! in)]
               (if (nil? msg)
@@ -41,10 +42,10 @@
   "Tries to connect to websocket at `url`; if sucessful, places a request map on `connection-chan`.
 Request maps contain following keys:
 
-  :uri  - the string URI on which the connection was made
-  :conn - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
-  :in   - a core.async port where you can put string messages
-  :out  - a core.async port whence string messages
+  :request - basic ring request map
+  :conn    - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
+  :in      - a core.async port where you can put string messages
+  :out     - a core.async port whence string messages
 
 Accepts the following options:
 
@@ -67,17 +68,17 @@ Accepts the following options:
   (proxy [WebSocketHandler] []
     (doWebSocketConnect [request response]
       (let [in (in-thunk) out (out-thunk)]
-        (->WebSocket$OnTextMessage connection-chan (.getRequestURI request) in out)))))
+        (->WebSocket$OnTextMessage connection-chan (servlet/build-request-map request) in out)))))
 
 (defn configurator
   "Returns a Jetty configurator that configures server to listen for websocket connections and put request maps on `connection-chan`.
 
 Request maps contain following keys:
 
-  :uri  - the string URI on which the connection was made
-  :conn - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
-  :in   - a core.async port where you can put string messages
-  :out  - a core.async port whence string messages
+  :request - basic ring request map
+  :conn    - the underlying Jetty7 websocket connection (see: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/websocket/WebSocket.Connection.html)
+  :in      - a core.async port where you can put string messages
+  :out     - a core.async port whence string messages
 
 Accepts the following options:
 

--- a/test/clj/com/keminglabs/jetty7_websockets_async/t_core.clj
+++ b/test/clj/com/keminglabs/jetty7_websockets_async/t_core.clj
@@ -99,7 +99,6 @@ Why is this not in core.async, yo?"
       (<!! new-connections 0 :empty) => :empty
       (connect! new-connections echo-url)
       (let [{:keys [conn in out uri] :as a} (<!! new-connections 100 :fail)]
-        (println a)
         uri => echo-url
         conn => #(instance? org.eclipse.jetty.websocket.WebSocket$Connection %)
         in => #(satisfies? clojure.core.async.impl.protocols/WritePort %)

--- a/test/clj/com/keminglabs/jetty7_websockets_async/t_core.clj
+++ b/test/clj/com/keminglabs/jetty7_websockets_async/t_core.clj
@@ -40,8 +40,9 @@ Why is this not in core.async, yo?"
              (proxy [WebSocket] []
                (onOpen [_])
                (onClose [_ _])))
-      (let [{:keys [conn in out uri]} (<!! new-connections 100 :fail)]
-        uri => ctx-path
+      (let [{:keys [conn in out request]} (<!! new-connections 100 :fail)]
+        request => map?
+        request => (contains {:uri ctx-path})
         conn => #(instance? org.eclipse.jetty.websocket.WebSocket$Connection %)
         in => #(satisfies? clojure.core.async.impl.protocols/WritePort %)
         out => #(satisfies? clojure.core.async.impl.protocols/ReadPort %)))
@@ -97,7 +98,8 @@ Why is this not in core.async, yo?"
     (fact "New websocket connections are put onto the channel"
       (<!! new-connections 0 :empty) => :empty
       (connect! new-connections echo-url)
-      (let [{:keys [conn in out uri]} (<!! new-connections 100 :fail)]
+      (let [{:keys [conn in out uri] :as a} (<!! new-connections 100 :fail)]
+        (println a)
         uri => echo-url
         conn => #(instance? org.eclipse.jetty.websocket.WebSocket$Connection %)
         in => #(satisfies? clojure.core.async.impl.protocols/WritePort %)


### PR DESCRIPTION
I needed cookie/session data when handling my websockets, so I'm building a request map using ring-servlet and adding to map sent over connection-chan rather than just URI. Allows access to basic set of request data, including headers, query params, [etc](https://github.com/ring-clojure/ring/blob/0cf09cc9a57e8a4422cdaa5783e62b7890a745d4/ring-servlet/src/ring/util/servlet.clj#L34-49). Not sure if you're interested in this, @lynaghk, since it changes the interface slightly, but others might find this helpful. I'll update the tests if you are interested
